### PR TITLE
Hvg harmony conos fix

### DIFF
--- a/scripts/runMethods.R
+++ b/scripts/runMethods.R
@@ -11,6 +11,7 @@ getScriptPath <- function(){
 setwd(getScriptPath())
 
 library('optparse')
+require(Seurat)
 
 option_list <- list(make_option(c("-m", "--method"), type="character", default=NA, help="integration method to use"),
 		    make_option(c("-i", "--input"), type="character", default=NA, help="input data"),


### PR DESCRIPTION
This PR fixes the missing hvg selection for harmony and conos.
`runMethods.r` is tested with harmony and hvg selection so far, the conos version is still running.