### PR TITLE
Diffusion method fix

### DIFF
--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -636,7 +636,7 @@ def select_hvg(adata, select=True):
         return adata
 
 ### diffusion for connectivites matrix extension
-def diffusion_conn(adata, min_k=50, copy=True, max_iterations=10):
+def diffusion_conn(adata, min_k=50, copy=True, max_iterations=14):
     '''
     This function performs graph diffusion on the connectivities matrix until a
     minimum number `min_k` of entries per row are non-zero.
@@ -704,7 +704,7 @@ def diffusion_conn(adata, min_k=50, copy=True, max_iterations=10):
 
     
 ### diffusion neighbourhood score
-def diffusion_nn(adata, k, max_iterations=10):
+def diffusion_nn(adata, k, max_iterations=14):
     '''
     This function generates a nearest neighbour list from a connectivities matrix
     as supplied by BBKNN or Conos. This allows us to select a consistent number


### PR DESCRIPTION
This change turns the diffusion into more of an aggregation of short random walks. In total, 3 main things were fixed.

1. sped up diffusion methods
2. changed to normalized connectivity matrix
3. fixed for case of disconnected graph

Speed up is particularly drastic the large the steps (4.5-fold speedup when 7 steps are needed, higher will be more).

Using the normalized connectivity matrix means diffusion_nn now has a higher similarity to using `sc.pp.neighbors()` with a higher k (tested on seurat, trVAE, and scanorama).