### PR TITLE
Add igraph to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(name='scIB',
           'anndata2ri',
           'scanorama',
           'memory_profiler',
-          'networkx>=2.3'
+          'networkx>=2.3',
+          'python-igraph'
       ],
       classifiers=[
          'Development Status :: 3 - Alpha',      


### PR DESCRIPTION
```
File "/home/travis/build/singlecellopenproblems/SingleCellOpenProblems/openproblems/tools/normalize.py", line 14, in log_scran_pooling
    scIB.preprocessing.normalize(adata)
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/scIB/preprocessing.py", line 166, in normalize
    sc.tl.louvain(adata_pp, key_added='groups', resolution=0.5)
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/scanpy/tools/_louvain.py", line 131, in louvain
    g = _utils.get_igraph_from_adjacency(adjacency, directed=directed)
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/scanpy/_utils.py", line 192, in get_igraph_from_adjacency
    import igraph as ig
ModuleNotFoundError: No module named 'igraph'
```