### PR TITLE
Add louvain dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(name='scIB',
           'scanorama',
           'memory_profiler',
           'networkx>=2.3',
-          'python-igraph'
+          'python-igraph',
+          'louvain>=0.6,!=0.6.2'
       ],
       classifiers=[
          'Development Status :: 3 - Alpha',      


### PR DESCRIPTION
Same issue as igraph, this is an optional dependency in scanpy.