### PR TITLE
[WIP] Free memory after running normalize

### DIFF
--- a/scIB/preprocessing.py
+++ b/scIB/preprocessing.py
@@ -185,6 +185,8 @@ def normalize(adata, min_mean = 0.1, log=True):
 
     # Free memory in R
     ro.r('rm(list=ls())')
+    ro.r('invisible(lapply(paste0("package:", names(sessionInfo()$otherPkgs)), '
+         'detach, character.only=TRUE, unload=TRUE))')
     ro.r('gc()')
 
 

--- a/scIB/preprocessing.py
+++ b/scIB/preprocessing.py
@@ -184,7 +184,7 @@ def normalize(adata, min_mean = 0.1, log=True):
     adata.raw = adata # Store the full data set in 'raw' as log-normalised data for statistical testing
 
     # Free memory in R
-    ro.r('rm(data_mat)')
+    ro.r('rm(list=ls())')
     ro.r('gc()')
 
 

--- a/scIB/preprocessing.py
+++ b/scIB/preprocessing.py
@@ -185,6 +185,7 @@ def normalize(adata, min_mean = 0.1, log=True):
 
     # Free memory in R
     ro.r('rm(list=ls())')
+    ro.r('lapply(names(sessionInfo()$loadedOnly), require, character.only = TRUE)')
     ro.r('invisible(lapply(paste0("package:", names(sessionInfo()$otherPkgs)), '
          'detach, character.only=TRUE, unload=TRUE))')
     ro.r('gc()')

--- a/scIB/preprocessing.py
+++ b/scIB/preprocessing.py
@@ -178,9 +178,15 @@ def normalize(adata, min_mean = 0.1, log=True):
         sc.pp.log1p(adata)
     else:
         print("No log-transformation performed after normalization.")
+
     # convert to sparse, bc operation always converts to dense
     adata.X = sparse.csr_matrix(adata.X)
     adata.raw = adata # Store the full data set in 'raw' as log-normalised data for statistical testing
+
+    # Free memory in R
+    ro.r('rm(data_mat)')
+    ro.r('gc()')
+
 
 def scale_batch(adata, batch):
     """


### PR DESCRIPTION
This PR relates to issue #155 

Running `scIB.pp.normalize()` starts an `R` kernel which requires memory that is not freed after running the function. 

Several things to try:
- [x] Deleting the objects moved to `R` 
- [x] Unloading modules in `R`
- [ ] Closing down the `R` kernel after the computation is done