### PR TITLE
Modify how embeddings are stored in Seurat objects

### DIFF
--- a/R/integration.R
+++ b/R/integration.R
@@ -23,7 +23,7 @@ runSeurat = function(data, batch, hvg=2000) {
         	  k.score = 30,
         	  max.features = 200,
         	  eps = 0)
-	integrated = IntegrateData(
+	  integrated = IntegrateData(
         	   anchorset = anchors,
 		   new.assay.name = "integrated",
         	   features = NULL,
@@ -37,7 +37,7 @@ runSeurat = function(data, batch, hvg=2000) {
         	   do.cpp = T,
         	   eps = 0,
         	   verbose = T)
-	return(integrated)
+	  return(integrated)
 }
 func_profiler = function(expr, chunksize=20000, filename='timing.out', prof.interval=0.02) {
 	      Rprof(filename, memory.profiling=T, interval=prof.interval)
@@ -55,7 +55,7 @@ func_profiler = function(expr, chunksize=20000, filename='timing.out', prof.inte
 #   out$memory is memory use
 
 preP <- function(so, vars.to.regress=NULL, verbose=TRUE, n.pcs=100) {
-    if (verbose) {
+  if (verbose) {
     message("Running Seurat v3 workflow")
   }
   so <- Seurat::FindVariableFeatures(object = so, verbose = verbose)
@@ -68,7 +68,7 @@ runConos = function(sobj, batch) {
 	require(conos)
 	require(Seurat)
 
-    batch_list <- SplitObject(sobj, split.by=batch)
+        batch_list <- SplitObject(sobj, split.by=batch)
  	pp <- lapply(batch_list, preP)
 
 	con <- Conos$new(pp)
@@ -91,12 +91,12 @@ runHarm = function(sobj, batch) {
 	require(harmony)
 	require(Seurat)
 
-    sobj <- ScaleData(sobj)
+        sobj <- ScaleData(sobj)
 	sobj <- RunPCA(sobj, features=rownames(sobj@assays$RNA))
 	sobj <- RunHarmony(sobj, batch)
 	sobj[['X_emb']] <- sobj[['harmony']]
 
-    return(sobj)
+        return(sobj)
 }
 
 runLiger = function(sobj, batch, hvg, k=20, res=0.4, small.clust.thresh=20) {

--- a/R/integration.R
+++ b/R/integration.R
@@ -99,7 +99,6 @@ runHarm = function(sobj, batch) {
 	sobj <- ScaleData(sobj)
 	sobj <- RunPCA(sobj, features=rownames(sobj@assays$RNA))
 	sobj <- RunHarmony(sobj, batch)
-	#sobj@reductions['X_emb'] <- sobj@reductions$harmony
 	sobj[['X_emb']] <- sobj[['harmony']]
     #harmonyEmb <- HarmonyMatrix(pca, method, batch, do_pca=F)
 	return(sobj)
@@ -149,7 +148,6 @@ runFastMNN = function(sobj, batch) {
 	sce <- fastMNN(expr, batch = sobj@meta.data[[batch]])
 
 	sobj@assays$RNA <- CreateAssayObject(assay(sce, "reconstructed"))
-	#sobj@reductions['X_emb'] <- CreateDimReducObject(reducedDim(sce, "corrected"), key='fastmnn_')
 	sobj[['X_emb']] <- CreateDimReducObject(reducedDim(sce, "corrected"), key='fastmnn_')
 
 	return(sobj)

--- a/R/integration.R
+++ b/R/integration.R
@@ -99,8 +99,9 @@ runHarm = function(sobj, batch) {
 	sobj <- ScaleData(sobj)
 	sobj <- RunPCA(sobj, features=rownames(sobj@assays$RNA))
 	sobj <- RunHarmony(sobj, batch)
-	sobj@reductions['X_emb'] <- sobj@reductions$harmony
-	#harmonyEmb <- HarmonyMatrix(pca, method, batch, do_pca=F)
+	#sobj@reductions['X_emb'] <- sobj@reductions$harmony
+	sobj[['X_emb']] <- sobj[['harmony']]
+    #harmonyEmb <- HarmonyMatrix(pca, method, batch, do_pca=F)
 	return(sobj)
 }
 
@@ -148,7 +149,8 @@ runFastMNN = function(sobj, batch) {
 	sce <- fastMNN(expr, batch = sobj@meta.data[[batch]])
 
 	sobj@assays$RNA <- CreateAssayObject(assay(sce, "reconstructed"))
-	sobj@reductions['X_emb'] <- CreateDimReducObject(reducedDim(sce, "corrected"), key='fastmnn_')
+	#sobj@reductions['X_emb'] <- CreateDimReducObject(reducedDim(sce, "corrected"), key='fastmnn_')
+	sobj[['X_emb']] <- CreateDimReducObject(reducedDim(sce, "corrected"), key='fastmnn_')
 
 	return(sobj)
 }

--- a/R/integration.R
+++ b/R/integration.R
@@ -54,9 +54,6 @@ func_profiler = function(expr, chunksize=20000, filename='timing.out', prof.inte
 #   out$time is timing
 #   out$memory is memory use
 
-
-
-
 preP <- function(so, vars.to.regress=NULL, verbose=TRUE, n.pcs=100) {
     if (verbose) {
     message("Running Seurat v3 workflow")
@@ -70,8 +67,8 @@ preP <- function(so, vars.to.regress=NULL, verbose=TRUE, n.pcs=100) {
 runConos = function(sobj, batch) {
 	require(conos)
 	require(Seurat)
-	#sobj <- loadSeuratObject(data)
-	batch_list <- SplitObject(sobj, split.by=batch)
+
+    batch_list <- SplitObject(sobj, split.by=batch)
  	pp <- lapply(batch_list, preP)
 
 	con <- Conos$new(pp)
@@ -79,10 +76,7 @@ runConos = function(sobj, batch) {
 	con$findCommunities()
 	con$embedGraph(method="UMAP")
 
-	#metadata <- data.frame(Cluster=con$clusters$leiden$groups)
-
 	return(con)
-
 }
 
 saveConos = function(con, outdir) {
@@ -96,12 +90,13 @@ saveConos = function(con, outdir) {
 runHarm = function(sobj, batch) {
 	require(harmony)
 	require(Seurat)
-	sobj <- ScaleData(sobj)
+
+    sobj <- ScaleData(sobj)
 	sobj <- RunPCA(sobj, features=rownames(sobj@assays$RNA))
 	sobj <- RunHarmony(sobj, batch)
 	sobj[['X_emb']] <- sobj[['harmony']]
-    #harmonyEmb <- HarmonyMatrix(pca, method, batch, do_pca=F)
-	return(sobj)
+
+    return(sobj)
 }
 
 runLiger = function(sobj, batch, hvg, k=20, res=0.4, small.clust.thresh=20) {

--- a/R/integration.R
+++ b/R/integration.R
@@ -68,7 +68,7 @@ runConos = function(sobj, batch) {
 	require(conos)
 	require(Seurat)
 
-        batch_list <- SplitObject(sobj, split.by=batch)
+      batch_list <- SplitObject(sobj, split.by=batch)
  	pp <- lapply(batch_list, preP)
 
 	con <- Conos$new(pp)
@@ -91,12 +91,12 @@ runHarm = function(sobj, batch) {
 	require(harmony)
 	require(Seurat)
 
-        sobj <- ScaleData(sobj)
+      sobj <- ScaleData(sobj)
 	sobj <- RunPCA(sobj, features=rownames(sobj@assays$RNA))
 	sobj <- RunHarmony(sobj, batch)
 	sobj[['X_emb']] <- sobj[['harmony']]
 
-        return(sobj)
+      return(sobj)
 }
 
 runLiger = function(sobj, batch, hvg, k=20, res=0.4, small.clust.thresh=20) {


### PR DESCRIPTION
For Harmony and fastMNN now store embeddings using `sobj[['X_emb']]` instead of `sobj@reductions['X_emb']`

Fixes #166 (hopefully)