### PR TITLE
Merge benchmarks into a single output file

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -196,7 +196,7 @@ rule metrics_single:
         i      = get_integrated_for_metrics,
         script = "scripts/metrics.py"
     output: cfg.get_filename_pattern("metrics", "single")
-    message: 
+    message:
         """
         Metrics {wildcards}
         output: {output}
@@ -207,7 +207,7 @@ rule metrics_single:
         organism  = lambda wildcards: cfg.get_from_scenario(wildcards.scenario, key="organism"),
         assay     = lambda wildcards: cfg.get_from_scenario(wildcards.scenario, key="assay"),
         hvgs      = lambda wildcards: cfg.get_feature_selection(wildcards.hvg),
-        cmd       = f"conda run -n {cfg.py_env} python"	
+        cmd       = f"conda run -n {cfg.py_env} python"
     shell:
         """
         {params.cmd} {input.script} -u {input.u} -i {input.i} -o {output} -m {wildcards.method} \
@@ -245,4 +245,21 @@ rule cc_single:
         {params.cmd} {input.script} -u {input.u} -i {input.i} -o {output} \
         -b {params.batch_key} --assay {params.assay} --type {wildcards.o_type} \
         --hvgs {params.hvgs} --organism {params.organism}
-        """    
+        """
+
+# ------------------------------------------------------------------------------
+# Merge benchmark files
+#
+# Run this after the main pipeline using:
+# snakemake --configfile config.yaml --cores 1 benchmarks
+# ------------------------------------------------------------------------------
+
+rule benchmarks:
+    input:
+        script = "scripts/merge_benchmarks.py"
+    output:
+        cfg.get_filename_pattern("benchmarks", "final")
+    message: "Merge all benchmarks"
+    params:
+        cmd = f"conda run -n {cfg.py_env} python"
+    shell: "{params.cmd} {input.script} -o {output} --root {cfg.ROOT}"

--- a/scripts/merge_benchmarks.py
+++ b/scripts/merge_benchmarks.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import argparse
+import os
+
+if __name__=='__main__':
+    """
+    Merge benchmark output for all scenarios, methods and settings
+    """
+
+    parser = argparse.ArgumentParser(description='Collect all benchmarks')
+
+    parser.add_argument('-o', '--output', required=True, help='output file')
+    parser.add_argument('-r', '--root', required=True,
+                        help='root directory for scIB output')
+    args = parser.parse_args()
+
+    bench_files = []
+    for path, dirs, files in os.walk(args.root):
+        for file in files:
+            if 'integration' in path and file.endswith('.benchmark'):
+                bench_files.append(os.path.join(path, file))
+
+    res_list = []
+    for file in bench_files:
+        clean_name = file.replace(args.root, "").replace(".benchmark", "")
+        res = pd.read_csv(file, sep='\t')
+        res.rename(columns={res.columns[1]: 'h_m_s'}, inplace=True)
+        res['scenario'] = clean_name
+        res.set_index('scenario', inplace=True)
+        res_list.append(res)
+
+    results = pd.concat(res_list)
+    results.to_csv(args.output, index_label='scenario')

--- a/scripts/snakemake_parse.py
+++ b/scripts/snakemake_parse.py
@@ -15,11 +15,12 @@ def join_path(*args):
 
 class ParsedConfig:
 
-    OUTPUT_FILE_TYPES = ['prepare', 'integration', 'metrics', 'metrics_unintegrated', 'cc_variance']
-    OUTPUT_LEVELS     = ['single', 'final', 'by_method', 'by_method_scaling', 
+    OUTPUT_FILE_TYPES = ['prepare', 'integration', 'metrics', 'metrics_unintegrated',
+                         'cc_variance', 'benchmarks']
+    OUTPUT_LEVELS     = ['single', 'final', 'by_method', 'by_method_scaling',
                          'directory_by_setting']
     OUTPUT_TYPES      = ['full', 'embed', 'knn']
-        
+
     def __init__(self, config):
 
         # TODO: define and check schema of config
@@ -134,7 +135,8 @@ class ParsedConfig:
             "prepare"     : "{method}.h5ad",
             "integration" : "{method}.h5ad",
             "metrics"     : "{method}_{o_type}.csv",
-            "cc_variance" : "{method}_{o_type}.csv"
+            "cc_variance" : "{method}_{o_type}.csv",
+            "benchmarks"  : None
         }
 
         # in case of R, we need a different suffix for the integration part
@@ -144,7 +146,7 @@ class ParsedConfig:
             file_suffixes["integration"] = "R/{method}.h5ad"
 
         suffix = file_suffixes[file_type]
-        
+
         if level == "single":
             return join_path(self.ROOT, "{scenario}", file_type, "{scaling}", "{hvg}", suffix)
         elif level == "directory_by_setting":
@@ -158,7 +160,7 @@ class ParsedConfig:
         #elif level == "scaled_final":
         #    return join_path(self.ROOT, f"{file_type}_scaled.csv")
 
-        
+
 
 
     def get_all_file_patterns(self, file_type, output_types=None):
@@ -182,7 +184,7 @@ class ParsedConfig:
                     raise ValueError(f"{output_types} not a valid output type")
 
         all_files = []
-        
+
         if file_type == 'metrics_unintegrated':
                 # add unintegrated
                 file_pattern = self.get_filename_pattern("metrics", "single")
@@ -229,4 +231,3 @@ class ParsedConfig:
                     all_files.extend(f)
 
         return all_files
-


### PR DESCRIPTION
This PR adds a script and Snakemake rule for merging all the `.benchmark` files produced by the main pipeline (when timing is turned on). It is not part of the main pipeline and needs to be run separately after that is complete. The output is a `benchmarks.csv` file in the same location as the `metrics.csv` file.

Briefly what the script does is:
1. Search the root output directory for files in an `integration/` direction ending in `.benchmark`
2. Read in these files and concatenate them
3. Save the result

The output file can then be easily used to compare the scalability of methods.