### PR TITLE
Fix LISI error for small values

### DIFF
--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -1376,10 +1376,10 @@ def lisi_graph_py(adata, batch_key, n_neighbors = 90, perplexity=None, subsample
     if verbose:
         print("Compute knn on shortest paths") 
     
-    #set connectivities to 2e-305 if they are lower than 1.7e-308 (because cpp can't handle double values smaller than that).
+    #set connectivities to 3e-308 if they are lower than 1.7e-308 (because cpp can't handle double values smaller than that).
     connectivities = adata.uns['neighbors']['connectivities'] #csr matrix format
-    large_enough = connectivities.data>=2e-305
-    connectivities.data[large_enough==False] = 2e-305
+    large_enough = connectivities.data>=1.7e-308
+    connectivities.data[large_enough==False] = 3e-308
     
     #define number of chunks
     n_chunks = 1

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
 #import networkx as nx
@@ -1379,6 +1380,11 @@ def lisi_graph_py(adata, batch_key, n_neighbors = 90, perplexity=None, subsample
     #set connectivities to 3e-308 if they are lower than 1.7e-308 (because cpp can't handle double values smaller than that).
     connectivities = adata.uns['neighbors']['connectivities'] #csr matrix format
     large_enough = connectivities.data>=1.7e-308
+    if verbose:
+        n_too_small = np.sum(large_enough==False)
+        if n_too_small:
+            print(f"{n_too_small} connectivities are too small and will be set to 3e-308")
+            print(connectivities.data[large_enough==False])
     connectivities.data[large_enough==False] = 3e-308
     
     #define number of chunks

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -1375,10 +1375,10 @@ def lisi_graph_py(adata, batch_key, n_neighbors = 90, perplexity=None, subsample
     if verbose:
         print("Compute knn on shortest paths") 
     
-    #set connectivities to 1.7e-308 if they are lower than 1.7e-308 (because cpp can't handle double values smaller than that).
+    #set connectivities to 2e-308 if they are lower than 1.7e-308 (because cpp can't handle double values smaller than that).
     connectivities = adata.uns['neighbors']['connectivities'] #csr matrix format
     large_enough = connectivities.data>=1.7e-308
-    connectivities.data[large_enough==False] = 1.7e-308
+    connectivities.data[large_enough==False] = 2e-308
     
     #define number of chunks
     n_chunks = 1

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -1375,10 +1375,10 @@ def lisi_graph_py(adata, batch_key, n_neighbors = 90, perplexity=None, subsample
     if verbose:
         print("Compute knn on shortest paths") 
     
-    #set connectivities to 2e-308 if they are lower than 1.7e-308 (because cpp can't handle double values smaller than that).
+    #set connectivities to 2e-305 if they are lower than 1.7e-308 (because cpp can't handle double values smaller than that).
     connectivities = adata.uns['neighbors']['connectivities'] #csr matrix format
-    large_enough = connectivities.data>=1.7e-308
-    connectivities.data[large_enough==False] = 2e-308
+    large_enough = connectivities.data>=2e-305
+    connectivities.data[large_enough==False] = 2e-305
     
     #define number of chunks
     n_chunks = 1

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -15,7 +15,7 @@ import cProfile
 from pstats import Stats
 import memory_profiler
 import itertools
-import multiprocessing
+import multiprocessing as multipro
 import subprocess
 import tempfile
 import pathlib
@@ -1387,7 +1387,7 @@ def lisi_graph_py(adata, batch_key, n_neighbors = 90, perplexity=None, subsample
         #set up multiprocessing
         if nodes is None:
             #take all but one CPU and 1 CPU, if there's only 1 CPU.
-            n_cpu = multiprocessing.cpu_count()
+            n_cpu = multipro.cpu_count()
             n_processes = np.max([ n_cpu, 
                                np.ceil(n_cpu/2)]).astype('int')
         else:
@@ -1425,7 +1425,7 @@ def lisi_graph_py(adata, batch_key, n_neighbors = 90, perplexity=None, subsample
 
         if verbose:
             print(f"{n_processes} processes started.")
-        pool = multiprocessing.Pool(processes=n_processes)
+        pool = multipro.Pool(processes=n_processes)
         count = np.arange(0, n_processes)
         
         #create argument list for each worker

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -9,6 +9,7 @@ from scipy import sparse
 from scipy.sparse.csgraph import connected_components
 from scipy.io import mmwrite
 import sklearn
+import sklearn.metrics
 
 from time import time
 import cProfile

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -1377,13 +1377,13 @@ def lisi_graph_py(adata, batch_key, n_neighbors = 90, perplexity=None, subsample
     if verbose:
         print("Compute knn on shortest paths") 
     
-    #set connectivities to 3e-308 if they are lower than 1.7e-308 (because cpp can't handle double values smaller than that).
+    #set connectivities to 3e-308 if they are lower than 3e-308 (because cpp can't handle double values smaller than that).
     connectivities = adata.uns['neighbors']['connectivities'] #csr matrix format
-    large_enough = connectivities.data>=1.7e-308
+    large_enough = connectivities.data>=3e-308
     if verbose:
         n_too_small = np.sum(large_enough==False)
         if n_too_small:
-            print(f"{n_too_small} connectivities are too small and will be set to 3e-308")
+            print(f"{n_too_small} connectivities are smaller than 3e-308 and will be set to 3e-308")
             print(connectivities.data[large_enough==False])
     connectivities.data[large_enough==False] = 3e-308
     

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -1375,6 +1375,11 @@ def lisi_graph_py(adata, batch_key, n_neighbors = 90, perplexity=None, subsample
     if verbose:
         print("Compute knn on shortest paths") 
     
+    #set connectivities to 1.7e-308 if they are lower than 1.7e-308 (because cpp can't handle double values smaller than that).
+    connectivities = adata.uns['neighbors']['connectivities'] #csr matrix format
+    large_enough = connectivities.data>=1.7e-308
+    connectivities.data[large_enough==False] = 1.7e-308
+    
     #define number of chunks
     n_chunks = 1
     
@@ -1399,7 +1404,7 @@ def lisi_graph_py(adata, batch_key, n_neighbors = 90, perplexity=None, subsample
     #write to temporary directory
     mtx_file_path = dir_path + 'input.mtx'
     mmwrite(mtx_file_path,
-            adata.uns['neighbors']['connectivities'],
+            connectivities,
             symmetry='general')
     # call knn-graph computation in Cpp
     


### PR DESCRIPTION
I replace some values in the connectivities matrix by the minimum value allowed as double in C++ (i.e. `1.7e-308`). Code is tested on two examples, however, I was unable to reproduce Luke's error message, when I set some values in the connectivities matrix to values smaller than `1.7e-308`.