### PR TITLE
Handle empty input files when saving embedding plots

### DIFF
--- a/scripts/save_embeddings.py
+++ b/scripts/save_embeddings.py
@@ -7,7 +7,6 @@ import argparse
 import os
 import sys
 import warnings
-from pathlib import Path
 
 warnings.filterwarnings('ignore')
 
@@ -50,16 +49,10 @@ if __name__=='__main__':
     if os.stat(args.input).st_size == 0:
         print(f'{args.input} is empty, empty output files will be created')
 
-        # Delete any old output files
-        for file in [labels_png, batches_png, outfile]:
-            if os.path.exists(file):
-                print(f'Deleting existing {file}')
-                os.remove(file)
-
         # Create empty output files
         for file in [labels_png, batches_png, outfile]:
             print(f'Creating empty {file}')
-            Path(file).touch()
+            open(file, "w").close()
 
         # End script
         sys.exit()


### PR DESCRIPTION
This was a bit trickier than I thought because I think the pipeline will complain if there is no output. What I have done is:

1. Check if the input `.h5ad` file is empty, if yes:
1. Delete any existing embedding output files
1. Create empty output files

I think it works but I have only tested it very quickly so probably good if @danielStrobl can try running it before we merge.