### PR TITLE
Avoid filtering in normalization

### DIFF
--- a/scIB/preprocessing.py
+++ b/scIB/preprocessing.py
@@ -184,7 +184,7 @@ def normalize(adata, min_mean = 0.1, log=True, precluster=True, sparsify=True):
     if precluster:
         # Preliminary clustering for differentiated normalisation
         adata_pp = adata.copy()
-        sc.pp.normalize_per_cell(adata_pp, counts_per_cell_after=1e6)
+        sc.pp.normalize_per_cell(adata_pp, counts_per_cell_after=1e6, min_counts=0)
         sc.pp.log1p(adata_pp)
         sc.pp.pca(adata_pp, n_comps=15, svd_solver='arpack')
         sc.pp.neighbors(adata_pp)


### PR DESCRIPTION
If cells are filtered in this stage, scran throws an error: 
`error in evaluating the argument 'object' in selecting a method for function 'sizeFactors': 'ncol(x)' is not equal to 'length(clusters)'`