### PR TITLE
Fix: Anndata concatenate causes shuffled batches

### DIFF
--- a/scIB/integration.py
+++ b/scIB/integration.py
@@ -6,20 +6,14 @@
     as well as tools and metrics to benchmark them.
 """
 
-import scanpy as sc
 import scipy as sp
-#import numpy as np
 from scIB.utils import *
-from memory_profiler import profile
 import os
-import pandas as pd
 import anndata
 
 import rpy2.rinterface_lib.callbacks
 import logging
 rpy2.rinterface_lib.callbacks.logger.setLevel(logging.ERROR) # Ignore R warning messages
-import rpy2.robjects as ro
-import anndata2ri
 from scipy.sparse import issparse
 
 # functions for running the methods
@@ -27,9 +21,11 @@ from scipy.sparse import issparse
 def runScanorama(adata, batch, hvg = None):
     import scanorama
     checkSanity(adata, batch, hvg)
-    split = splitBatches(adata.copy(), batch)
+    split, categories = splitBatches(adata.copy(), batch, return_categories=True)
     corrected = scanorama.correct_scanpy(split, return_dimred=True)
-    corrected = corrected[0].concatenate(corrected[1:])
+    corrected = anndata.AnnData.concatenate(
+        *corrected, batch_key=batch, batch_categories=categories
+    )
     corrected.obsm['X_emb'] = corrected.obsm['X_scanorama']
     #corrected.uns['emb']=True
 
@@ -278,11 +274,13 @@ def runScanvi(adata, batch, labels):
 def runMNN(adata, batch, hvg = None):
     import mnnpy
     checkSanity(adata, batch, hvg)
-    split = splitBatches(adata, batch)
+    split, categories = splitBatches(adata, batch, return_categories=True)
 
-    corrected = mnnpy.mnn_correct(*split, var_subset=hvg)
+    corrected, _, _ = mnnpy.mnn_correct(
+        *split, var_subset=hvg, batch_key=batch, batch_categories=categories
+    )
 
-    return corrected[0]
+    return corrected
 
 def runBBKNN(adata, batch, hvg=None):
     import bbknn

--- a/scIB/integration.py
+++ b/scIB/integration.py
@@ -24,7 +24,7 @@ def runScanorama(adata, batch, hvg = None):
     split, categories = splitBatches(adata.copy(), batch, return_categories=True)
     corrected = scanorama.correct_scanpy(split, return_dimred=True)
     corrected = anndata.AnnData.concatenate(
-        *corrected, batch_key=batch, batch_categories=categories
+        *corrected, batch_key=batch, batch_categories=categories, index_unique=None
     )
     corrected.obsm['X_emb'] = corrected.obsm['X_scanorama']
     #corrected.uns['emb']=True
@@ -277,7 +277,7 @@ def runMNN(adata, batch, hvg = None):
     split, categories = splitBatches(adata, batch, return_categories=True)
 
     corrected, _, _ = mnnpy.mnn_correct(
-        *split, var_subset=hvg, batch_key=batch, batch_categories=categories
+        *split, var_subset=hvg, batch_key=batch, batch_categories=categories, index_unique=None
     )
 
     return corrected

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -409,7 +409,7 @@ def precompute_hvg_batch(adata, batch, features, n_hvg=500, save_hvg=False):
             print('Number of genes: '+str(i.n_vars))
         hvg = sc.pp.highly_variable_genes(i, flavor='cell_ranger', n_top_genes=n_hvg_tmp, inplace=False)
         hvg_dir[i.obs[batch][0]] = i.var.index[hvg['highly_variable']]
-    adata_list=None
+
     if save_hvg:    
         adata.uns['hvg_before']=hvg_dir
     else:
@@ -563,7 +563,7 @@ def cell_cycle(adata_pre, adata_post, batch_key, embed=None, agg_func=np.mean,
         
             if raw_sub.shape[0] != int_sub.shape[0]:
                 message = f'batch "{batch}" of batch_key "{batch_key}" '
-                message += 'has unequal number of entries before and after integration.'
+                message += 'has unequal number of observations before and after integration.'
                 message += f'before: {raw_sub.shape[0]} after: {int_sub.shape[0]}'
                 raise ValueError(message)
         

--- a/scIB/utils.py
+++ b/scIB/utils.py
@@ -28,12 +28,15 @@ def checkSanity(adata, batch, hvg):
         checkHVG(hvg, adata.var)
 
 
-def splitBatches(adata, batch, hvg= None):
+def splitBatches(adata, batch, hvg= None, return_categories=False):
     split = []
+    batch_categories = adata.obs[batch].unique()
     if hvg is not None:
         adata = adata[:, hvg]
-    for i in adata.obs[batch].unique():
+    for i in batch_categories:
         split.append(adata[adata.obs[batch]==i].copy())
+    if return_categories:
+        return split, batch_categories
     return split
 
 def merge_adata(adata_list, sep='-'):


### PR DESCRIPTION
When we use `Anndata.concatenate` and specify the `batch_key` parameter, we need to ensure that the correct batch categories are passed to the method as well. Otherwise these will be overwritten with batches `0:n_batches-1`.
On the test data, the batch key is 'batch', the same as the default value of `batch_key` in `Anndata.concatenate`. This results in shuffled batches after concatenating anndata objects split by batch.

Fixes

- provide option in `utils.splitBatches` to return the batches categories
- pass batch categories to `Anndata.concatenate` function together with `batch_key`, so that correct batch annotations are retained