### PR TITLE
Allow specific pseudotime column for TI metric

### DIFF
--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -1699,7 +1699,7 @@ def kBET(adata, batch_key, label_key, embed='X_pca', type_ = None,
     return kBET_scores
 
 
-def get_root(adata_pre, adata_post, ct_key, pseudotime_key, dpt_dim=3):
+def get_root(adata_pre, adata_post, ct_key, pseudotime_key="dpt_pseudotime", dpt_dim=3):
     """
     Determine root cell for integrated adata based on unintegrated adata
 

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -1771,6 +1771,7 @@ def trajectory_conservation(adata_pre, adata_post, label_key, pseudotime_key="dp
     adata_post_sub2.obs['dpt_pseudotime'][adata_post_sub2.obs['dpt_pseudotime'] > 1] = 0
     adata_post_sub.obs['dpt_pseudotime'] = 0
     adata_post_sub.obs['dpt_pseudotime'] = adata_post_sub2.obs['dpt_pseudotime']
+    adata_post_sub.obs['dpt_pseudotime'].fillna(0, inplace=True)
 
     correlation = adata_post_sub.obs['dpt_pseudotime'].corr(adata_pre_sub.obs['dpt_pseudotime'], 'spearman')
 

--- a/scIB/metrics.py
+++ b/scIB/metrics.py
@@ -1698,18 +1698,31 @@ def kBET(adata, batch_key, label_key, embed='X_pca', type_ = None,
     
     return kBET_scores
 
-# determine root cell for trajectory conservation metric
-def get_root(adata_pre, adata_post, ct_key, dpt_dim=3):
-    
-    n_components, adata_post.obs['neighborhood'] = connected_components(csgraph=adata_post.obsp['connectivities'], directed=False, return_labels=True)
-    
-    start_clust = adata_pre.obs.groupby([ct_key]).mean()['dpt_pseudotime'].idxmin()
+
+def get_root(adata_pre, adata_post, ct_key, pseudotime_key, dpt_dim=3):
+    """
+    Determine root cell for integrated adata based on unintegrated adata
+
+    :param adata_pre: unintegrated adata
+    :param adata_post: integrated adata
+    :param label_key: column in `adata_pre.obs` of the groups used to precompute the trajectory
+    :param pseudotime_key: column in `adata_pre.obs` in which the pseudotime is saved in.
+        Column can contain empty entries, the dataset will be subset to the cells with scores.
+    :param dpt_dim: number of dimensions used for DPT
+    """
+    n_components, adata_post.obs['neighborhood'] = connected_components(
+        csgraph=adata_post.obsp['connectivities'],
+        directed=False,
+        return_labels=True
+    )
+
+    start_clust = adata_pre.obs.groupby([ct_key]).mean()[pseudotime_key].idxmin()
     min_dpt = adata_pre.obs[adata_pre.obs[ct_key] == start_clust].index
     #print(min_dpt)
-    max_neigh = adata_post.obs[adata_post.obs['neighborhood']== adata_post.obs['neighborhood'].value_counts().idxmax()].index
-    min_dpt = [value for value in min_dpt if value in max_neigh]
-    
-    adata_post_sub = adata_post[adata_post.obs['neighborhood']== adata_post.obs['neighborhood'].value_counts().idxmax()]
+    which_max_neigh = adata_post.obs['neighborhood'] == adata_post.obs['neighborhood'].value_counts().idxmax()
+    min_dpt = [value for value in min_dpt if value in adata_post.obs[which_max_neigh].index]
+
+    adata_post_sub = adata_post[which_max_neigh]
     
     min_dpt = [adata_post_sub.obs_names.get_loc(i) for i in min_dpt]
     
@@ -1719,7 +1732,7 @@ def get_root(adata_pre, adata_post, ct_key, dpt_dim=3):
     # determine most extreme cell in adata_post Diffmap
     min_dpt_cell = np.zeros(len(min_dpt))
     for dim in np.arange(dpt_dim):
-        
+
         diffmap_mean = adata_post_sub.obsm["X_diffmap"][:, dim].mean()
         diffmap_min_dpt = adata_post_sub.obsm["X_diffmap"][min_dpt, dim]
         
@@ -1728,28 +1741,40 @@ def get_root(adata_pre, adata_post, ct_key, dpt_dim=3):
             opt = np.argmin
         else:
             opt = np.argmax
+
         # count opt cell
         if len(diffmap_min_dpt) == 0:
             raise RootCellError('No root cell in largest component')
+
         min_dpt_cell[opt(diffmap_min_dpt)] += 1
     
     # root cell is cell with max vote
     return min_dpt[np.argmax(min_dpt_cell)], adata_post_sub
 
-def trajectory_conservation(adata_pre, adata_post, label_key):
-    cell_subset = adata_pre.obs.index[adata_pre.obs["dpt_pseudotime"].notnull()]
+def trajectory_conservation(adata_pre, adata_post, label_key, pseudotime_key="dpt_pseudotime"):
+    """
+    :param adata_pre: unintegrated adata
+    :param adata_post: integrated adata
+    :param label_key: column in `adata_pre.obs` of the groups used to precompute the trajectory
+    :param pseudotime_key: column in `adata_pre.obs` in which the pseudotime is saved in.
+        Column can contain empty entries, the dataset will be subset to the cells with scores.
+    """
+    # subset to cells for which pseudotime has been computed
+    cell_subset = adata_pre.obs.index[adata_pre.obs[pseudotime_key].notnull()]
     adata_pre_sub = adata_pre[cell_subset]
     adata_post_sub = adata_post[cell_subset]
-    
-    iroot, adata_post_sub2 = get_root(adata_pre_sub, adata_post_sub, label_key)
+
+    iroot, adata_post_sub2 = get_root(adata_pre_sub, adata_post_sub, label_key, pseudotime_key)
     adata_post_sub2.uns['iroot'] = iroot
     
-    sc.tl.dpt(adata_post_sub2)
-    adata_post_sub2.obs['dpt_pseudotime'][adata_post_sub2.obs['dpt_pseudotime']>1]=0
+    sc.tl.dpt(adata_post_sub2)  # stored in 'dpt_pseudotime'
+    adata_post_sub2.obs['dpt_pseudotime'][adata_post_sub2.obs['dpt_pseudotime'] > 1] = 0
     adata_post_sub.obs['dpt_pseudotime'] = 0
     adata_post_sub.obs['dpt_pseudotime'] = adata_post_sub2.obs['dpt_pseudotime']
-    adata_post_sub.obs['dpt_pseudotime'].fillna(0)
-    return (adata_post_sub.obs['dpt_pseudotime'].corr(adata_pre_sub.obs['dpt_pseudotime'], 'spearman')+1)/2
+
+    correlation = adata_post_sub.obs['dpt_pseudotime'].corr(adata_pre_sub.obs['dpt_pseudotime'], 'spearman')
+
+    return (correlation + 1)/2  # scaled
 
 
 def graph_connectivity(adata_post, label_key):


### PR DESCRIPTION
Currently metric assumes pseudotime to be saved under 'dpt_pseudotime'. For some use-cases we would want to be able to specifiy different pseudotime columns in `.obs`.