### PR TITLE
Move anndata2ri.activate() up in kBET_single

### DIFF
--- a/scIB/metrics/kbet.py
+++ b/scIB/metrics/kbet.py
@@ -32,6 +32,7 @@ def kBET_single(
         kBET observed rejection rate
     """
     ro.r("library(kBET)")
+    anndata2ri.activate()
 
     if verbose:
         print("importing expression matrix")
@@ -44,7 +45,6 @@ def kBET_single(
         print("kBET estimation")
     # k0 = len(batch) if len(batch) < 50 else 'NULL'
 
-    anndata2ri.activate()
     ro.globalenv['knn_graph'] = knn
     ro.globalenv['k0'] = k0
     ro.r(


### PR DESCRIPTION
Fixes #266. This is not the ideal fix but it works :) see the code in #266 for why. Something deactivates the global anndata2ri converter down the line.