### PR TITLE
Add **kwds to be able to access method-specific arguments

### DIFF
--- a/scIB/integration.py
+++ b/scIB/integration.py
@@ -21,7 +21,7 @@ from scipy.sparse import issparse
 
 # functions for running the methods
 
-def runScanorama(adata, batch, hvg=None):
+def runScanorama(adata, batch, hvg=None, **kwds):
     try:
         import scanorama
     except ModuleNotFoundError as e:
@@ -29,7 +29,7 @@ def runScanorama(adata, batch, hvg=None):
 
     checkSanity(adata, batch, hvg)
     split, categories = splitBatches(adata.copy(), batch, return_categories=True)
-    corrected = scanorama.correct_scanpy(split, return_dimred=True)
+    corrected = scanorama.correct_scanpy(split, return_dimred=True, **kwds)
     corrected = anndata.AnnData.concatenate(
         *corrected, batch_key=batch, batch_categories=categories, index_unique=None
     )
@@ -126,7 +126,7 @@ def runTrVaep(adata, batch, hvg=None):
     return adata
 
 
-def runScGen(adata, batch, cell_type, epochs=100, hvg=None, model_path='/localscratch'):
+def runScGen(adata, batch, cell_type, epochs=100, hvg=None, model_path='/localscratch', **kwds):
     """
     Parametrization taken from the tutorial notebook at:
     https://nbviewer.jupyter.org/github/M0hammadL/scGen_notebooks/blob/master/notebooks/scgen_batch_removal.ipynb
@@ -141,7 +141,7 @@ def runScGen(adata, batch, cell_type, epochs=100, hvg=None, model_path='/localsc
     # Fit the model
     network = scgen.VAEArith(x_dimension=adata.shape[1], model_path=model_path)
     network.train(train_data=adata, n_epochs=epochs, save=False)
-    corrected_adata = scgen.batch_removal(network, adata, batch_key=batch, cell_label_key=cell_type)
+    corrected_adata = scgen.batch_removal(network, adata, batch_key=batch, cell_label_key=cell_type, **kwds)
 
     network.sess.close()
 
@@ -297,7 +297,7 @@ def runScanvi(adata, batch, labels):
     return adata
 
 
-def runMNN(adata, batch, hvg=None):
+def runMNN(adata, batch, hvg=None, **kwds):
     try:
         import mnnpy
     except ModuleNotFoundError as e:
@@ -307,13 +307,18 @@ def runMNN(adata, batch, hvg=None):
     split, categories = splitBatches(adata, batch, return_categories=True)
 
     corrected, _, _ = mnnpy.mnn_correct(
-        *split, var_subset=hvg, batch_key=batch, batch_categories=categories, index_unique=None
+        *split,
+        var_subset=hvg,
+        batch_key=batch,
+        batch_categories=categories,
+        index_unique=None,
+        **kwds,
     )
 
     return corrected
 
 
-def runBBKNN(adata, batch, hvg=None):
+def runBBKNN(adata, batch, hvg=None, **kwds):
     try:
         import bbknn
     except ModuleNotFoundError as e:
@@ -322,9 +327,9 @@ def runBBKNN(adata, batch, hvg=None):
     checkSanity(adata, batch, hvg)
     sc.pp.pca(adata, svd_solver='arpack')
     if adata.n_obs < 1e5:
-        return bbknn.bbknn(adata, batch_key=batch, copy=True)
+        return bbknn.bbknn(adata, batch_key=batch, copy=True, **kwds)
     if adata.n_obs >= 1e5:
-        return bbknn.bbknn(adata, batch_key=batch, neighbors_within_batch=25, copy=True)
+        return bbknn.bbknn(adata, batch_key=batch, neighbors_within_batch=25, copy=True, **kwds)
 
 
 def runSaucie(adata, batch):


### PR DESCRIPTION
I needed to access arguments like `pynndescent_random_state` in bbknn, so I thought it might make sense to add **kwds to these methods so that users can specify method-specific arguments.