### PR TITLE
Improve LISI multiprocessing specification

### DIFF
--- a/scib/metrics/lisi.py
+++ b/scib/metrics/lisi.py
@@ -315,12 +315,11 @@ def lisi_graph_py(
         )
         simpson_est_batch = 1 / simpson_estimate_batch
 
-    tmpdir.cleanup()
 
     # extract results
     d = {batch_key: simpson_est_batch}
-
     lisi_estimate = pd.DataFrame(data=d, index=np.arange(0, len(simpson_est_batch)))
+    tmpdir.cleanup()
 
     return lisi_estimate
 

--- a/scib/metrics/lisi.py
+++ b/scib/metrics/lisi.py
@@ -284,7 +284,7 @@ def lisi_graph_py(
         pool.close()
         pool.join()
 
-        simpson_est_batch = 1 / np.concatenate(results)
+        simpson_estimate_batch = np.concatenate(results)
 
     else:
         simpson_estimate_batch = compute_simpson_index_graph(
@@ -294,15 +294,10 @@ def lisi_graph_py(
             perplexity=perplexity,
             n_neighbors=n_neighbors
         )
-        simpson_est_batch = 1 / simpson_estimate_batch
 
-
-    # extract results
-    d = {batch_key: simpson_est_batch}
-    lisi_estimate = pd.DataFrame(data=d, index=np.arange(0, len(simpson_est_batch)))
     tmpdir.cleanup()
 
-    return lisi_estimate
+    return 1 / simpson_estimate_batch
 
 
 # LISI core functions

--- a/scib/metrics/metrics.py
+++ b/scib/metrics/metrics.py
@@ -456,7 +456,7 @@ def metrics(
             type_=type_,
             subsample=subsample * 100,
             scale=True,
-            multiprocessing=False,
+            multiprocessing=None,
             verbose=verbose
         )
     else:
@@ -470,7 +470,7 @@ def metrics(
             type_=type_,
             subsample=subsample * 100,
             scale=True,
-            multiprocessing=False,
+            multiprocessing=None,
             verbose=verbose
         )
     else:

--- a/scib/metrics/metrics.py
+++ b/scib/metrics/metrics.py
@@ -217,6 +217,7 @@ def metrics(
         ilisi_=False,
         clisi_=False,
         subsample=0.5,
+        n_cores=1,
         type_=None,
         verbose=False,
 ):
@@ -456,7 +457,7 @@ def metrics(
             type_=type_,
             subsample=subsample * 100,
             scale=True,
-            multiprocessing=None,
+            n_cores=n_cores,
             verbose=verbose
         )
     else:
@@ -470,7 +471,7 @@ def metrics(
             type_=type_,
             subsample=subsample * 100,
             scale=True,
-            multiprocessing=None,
+            n_cores=n_cores,
             verbose=verbose
         )
     else:

--- a/scib/metrics/metrics.py
+++ b/scib/metrics/metrics.py
@@ -456,7 +456,7 @@ def metrics(
             type_=type_,
             subsample=subsample * 100,
             scale=True,
-            multiprocessing=True,
+            multiprocessing=False,
             verbose=verbose
         )
     else:
@@ -470,7 +470,7 @@ def metrics(
             type_=type_,
             subsample=subsample * 100,
             scale=True,
-            multiprocessing=True,
+            multiprocessing=False,
             verbose=verbose
         )
     else:

--- a/tests/metrics/test_clisi.py
+++ b/tests/metrics/test_clisi.py
@@ -1,13 +1,13 @@
 from tests.common import *
 
-
 def test_clisi_full(adata):
     score = scib.me.clisi_graph(
         adata,
         batch_key='batch',
         label_key='celltype',
         scale=True,
-        type_='full'
+        type_='full',
+        verbose=True
     )
 
     LOGGER.info(f"score: {score}")
@@ -21,7 +21,8 @@ def test_clisi_embed(adata_neighbors):
         batch_key='batch',
         label_key='celltype',
         scale=True,
-        type_='embed'
+        type_='embed',
+        verbose=True
     )
     LOGGER.info(f"score: {score}")
     assert_near_exact(score, 0.982, diff=1e-2)
@@ -33,7 +34,8 @@ def test_clisi_knn(adata_neighbors):
         batch_key='batch',
         label_key='celltype',
         scale=True,
-        type_='graph'
+        type_='graph',
+        verbose=True
     )
     LOGGER.info(f"score: {score}")
     assert_near_exact(score, 0.982, diff=1e-2)

--- a/tests/metrics/test_ilisi.py
+++ b/tests/metrics/test_ilisi.py
@@ -6,7 +6,8 @@ def test_ilisi_full(adata):
         adata,
         batch_key='batch',
         scale=True,
-        type_='full'
+        type_='full',
+        verbose=True
     )
 
     LOGGER.info(f"score: {score}")
@@ -19,7 +20,8 @@ def test_ilisi_embed(adata_neighbors):
         adata_neighbors,
         batch_key='batch',
         scale=True,
-        type_='embed'
+        type_='embed',
+        verbose=True
     )
     LOGGER.info(f"score: {score}")
     assert_near_exact(score, 0.238, diff=1e-2)
@@ -30,7 +32,8 @@ def test_ilisi_knn(adata_neighbors):
         adata_neighbors,
         batch_key='batch',
         scale=True,
-        type_='graph'
+        type_='graph',
+        verbose=True
     )
     LOGGER.info(f"score: {score}")
     assert_near_exact(score, 0.238, diff=1e-2)


### PR DESCRIPTION
LISI supports multiprocessing, however specifying the number of cores and whether to use multiprocessing is not well defined.
Here I address

1. remove `multiprocessing` key from lisi functions
2. rename `nodes` to `n_cores`
3. use default `n_cores=1` for running without parallelisation