### PR TITLE
Set revision for kBET installation

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -34,7 +34,7 @@ Additionally, in order to run the R package ``kBET``, you need to install it thr
 
 .. code-block:: R
 
-    devtools::install_github('theislab/kBET')
+    devtools::install_github('theislab/kBET@4c9dafa')
 
 
 .. note::


### PR DESCRIPTION
Latest commit in kBET package breaks backward compatibility for R=3.6.1.

https://github.com/theislab/kBET/blob/2e2b09179bba4808903d04e4425f9d5cdbeaa989/R/kBET.R#L195