### PR TITLE
Bump rp2y dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,11 +57,11 @@ jobs:
                 pip install '.[test]'
 
         -   name: Test with pytest
-            if: ${{ matrix.os }} != 'macos-latest'
+            if: matrix.os != 'macos-latest'
             run: |
                 python -m pytest --cov --cov-append --cov-report=term-missing --ignore=tests/integration/ -vv
         -   name: Upload coverage
-            if: ${{ matrix.os }} != 'macos-latest'
+            if: matrix.os != 'macos-latest'
             env:
                 CODECOV_NAME: ${{ matrix.os }}-${{ matrix.python }}
             run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         strategy:
             matrix:
                 python: [3.7, 3.9]
-                os: [ubuntu-latest, macos-latest]
+                os: [ubuntu-latest]
         steps:
         -   uses: actions/checkout@v2
         -   name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         strategy:
             matrix:
                 python: [3.7, 3.9]
-                os: [ubuntu-latest]
+                os: [ubuntu-latest, macos-latest]
         steps:
         -   uses: actions/checkout@v2
         -   name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,11 +57,11 @@ jobs:
                 pip install '.[test]'
 
         -   name: Test with pytest
-            if: matrix.os != 'macos-latest'
+            if: ${{ matrix.os != 'macos-latest'}}
             run: |
                 python -m pytest --cov --cov-append --cov-report=term-missing --ignore=tests/integration/ -vv
         -   name: Upload coverage
-            if: matrix.os != 'macos-latest'
+            if: ${{ matrix.os != 'macos-latest' }}
             env:
                 CODECOV_NAME: ${{ matrix.os }}-${{ matrix.python }}
             run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,15 +57,15 @@ jobs:
                 pip install '.[test]'
 
         -   name: Test with pytest
+            if: ${{ matrix.os }} != 'macos-latest'
             run: |
                 python -m pytest --cov --cov-append --cov-report=term-missing --ignore=tests/integration/ -vv
-            if: ${{ matrix.os = 'ubuntu-latest' }}
         -   name: Upload coverage
+            if: ${{ matrix.os }} != 'macos-latest'
             env:
                 CODECOV_NAME: ${{ matrix.os }}-${{ matrix.python }}
             run: |
                 codecov --no-color --required --flags unittest
-            if: ${{ matrix.os = 'ubuntu-latest' }}
 
     integration:
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,11 +59,13 @@ jobs:
         -   name: Test with pytest
             run: |
                 python -m pytest --cov --cov-append --cov-report=term-missing --ignore=tests/integration/ -vv
+            if: ${{ matrix.os = 'ubuntu-latest' }}
         -   name: Upload coverage
             env:
                 CODECOV_NAME: ${{ matrix.os }}-${{ matrix.python }}
             run: |
                 codecov --no-color --required --flags unittest
+            if: ${{ matrix.os = 'ubuntu-latest' }}
 
     integration:
         runs-on: ${{ matrix.os }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
     leidenalg
 	umap-learn
 	pydot
-	igraph<0.10
+	igraph
 	llvmlite
 	deprecated
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ classifiers =
 	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
 
 [bdist_wheel]
 build_number = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,9 +59,10 @@ install_requires =
 	scikit-learn
 	scikit-misc
 	louvain
+    leidenalg
 	umap-learn
 	pydot
-	python-igraph
+	igraph<0.10
 	llvmlite
 	deprecated
 zip_safe = False


### PR DESCRIPTION
Unpin rpy2 dependency and make sure test run through without failing. This will close #322 

Skipping pytest on macos (due to unresolved segmentation fault)