### PR TITLE
Update louvain call to a more recent method

### DIFF
--- a/scib/metrics/clustering.py
+++ b/scib/metrics/clustering.py
@@ -79,7 +79,7 @@ def opt_louvain(
         sc.pp.neighbors(adata, use_rep=use_rep)
 
     for res in resolutions:
-        sc.tl.louvain(adata, resolution=res, key_added=cluster_key)
+        sc.tl.leiden(adata, resolution=res, key_added=cluster_key)
         score = function(adata, label_key, cluster_key, **kwargs)
         if verbose:
             print(f"resolution: {res}, {function.__name__}: {score}")


### PR DESCRIPTION
Current version raises `BaseException: Could not construct partition: vector` error when calculating metrics that use Louvain clustering algorithm. As discussed in https://github.com/vtraag/louvain-igraph/issues/61 and [scanpy docs](https://scanpy-tutorials.readthedocs.io/en/latest/paga-paul15.html#Clustering-and-PAGA), the code should use `sc.tl.leiden` instead.

