### PR TITLE
Update louvain to 0.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,11 +56,11 @@ install_requires =
 	scipy
 	scikit-learn
 	scikit-misc
-	louvain
+	louvain>=0.8
 	leidenalg
 	umap-learn
 	pydot
-	igraph<0.10
+	igraph>=0.10
 	llvmlite
 	deprecated
 zip_safe = False


### PR DESCRIPTION
A new version of louvain has been released after quite some time. This PR updates scIB to use the new version, unpinning igraph.