### PR TITLE
Update isolated_labels.py

### DIFF
--- a/scib/metrics/isolated_labels.py
+++ b/scib/metrics/isolated_labels.py
@@ -226,7 +226,7 @@ def score_isolated_label(
     else:
         # AWS score between isolated label vs rest
         adata.obs[iso_label_key] = adata.obs[label_key] == isolated_label
-        adata.obs['silhouette_temp'] = silhouette_samples(
+        adata.obs["silhouette_temp"] = silhouette_samples(
             adata.obsm[embed], adata.obs[iso_label_key]
         )
         score = adata.obs[adata.obs[iso_label_key]].silhouette_temp.mean()

--- a/scib/metrics/isolated_labels.py
+++ b/scib/metrics/isolated_labels.py
@@ -1,9 +1,7 @@
 import pandas as pd
-from sklearn.metrics import f1_score
-from sklearn.metrics import silhouette_samples
+from sklearn.metrics import f1_score, silhouette_samples
 
 from .clustering import cluster_optimal_resolution
-from .silhouette import silhouette
 
 
 def isolated_labels_f1(
@@ -228,7 +226,9 @@ def score_isolated_label(
     else:
         # AWS score between isolated label vs rest
         adata.obs[iso_label_key] = adata.obs[label_key] == isolated_label
-        adata.obs['silhouette_temp'] = silhouette_samples(adata.obsm[embed], adata.obs[iso_label_key])
+        adata.obs['silhouette_temp'] = silhouette_samples(
+            adata.obsm[embed], adata.obs[iso_label_key]
+        )
         score = adata.obs[adata.obs[iso_label_key]].silhouette_temp.mean()
 
     if verbose:

--- a/scib/metrics/isolated_labels.py
+++ b/scib/metrics/isolated_labels.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from sklearn.metrics import f1_score
+from sklearn.metrics import silhouette_samples
 
 from .clustering import cluster_optimal_resolution
 from .silhouette import silhouette
@@ -227,7 +228,8 @@ def score_isolated_label(
     else:
         # AWS score between isolated label vs rest
         adata.obs[iso_label_key] = adata.obs[label_key] == isolated_label
-        score = silhouette(adata, iso_label_key, embed)
+        adata.obs['silhouette_temp'] = silhouette_samples(adata.obsm[embed], adata.obs[iso_label_key])
+        score = adata.obs[adata.obs[iso_label_key]].silhouette_temp.mean()
 
     if verbose:
         print(f"{isolated_label}: {score}")

--- a/tests/metrics/test_isolated_label.py
+++ b/tests/metrics/test_isolated_label.py
@@ -43,7 +43,7 @@ def test_isolated_labels_ASW(adata_pca):
         verbose=True,
     )
     LOGGER.info(f"score: {score}")
-    assert_near_exact(score, 0.6101431176066399, diff=1e-3)
+    assert_near_exact(score, 0.1938440054655075, diff=1e-3)
 
 
 def test_isolated_labels_perfect(adata_pca):

--- a/tests/metrics/test_silhouette_metrics.py
+++ b/tests/metrics/test_silhouette_metrics.py
@@ -53,4 +53,4 @@ def test_isolated_labels_silhouette(adata_pca):
         verbose=True,
     )
     LOGGER.info(f"score: {score}")
-    assert_near_exact(score, 0.6101431176066399, diff=1e-3)
+    assert_near_exact(score, 0.1938440054655075, diff=1e-3)


### PR DESCRIPTION
As mentioned in https://github.com/theislab/scib/issues/367, the isolated label metrics do not compute what they should.
By calculating the individual silhouette scores and then taking the mean over only the cells of the cluster, this should be fixed.