### PR TITLE
Scale isolated label ASW

### DIFF
--- a/scib/metrics/isolated_labels.py
+++ b/scib/metrics/isolated_labels.py
@@ -67,6 +67,7 @@ def isolated_labels_asw(
     batch_key,
     embed,
     iso_threshold=None,
+    scale=True,
     verbose=True,
 ):
     """Isolated label score ASW
@@ -81,6 +82,7 @@ def isolated_labels_asw(
     :param iso_threshold: max number of batches per label for label to be considered as
         isolated, if iso_threshold is integer.
         If ``iso_threshold=None``, consider minimum number of batches that labels are present in
+    :param scale: Whether to scale the score between 0 and 1. Only relevant for ASW scores.
     :param verbose:
     :return: Mean of ASW over all isolated labels
 
@@ -105,7 +107,6 @@ def isolated_labels_asw(
         )
 
     """
-
     return isolated_labels(
         adata,
         label_key=label_key,
@@ -113,6 +114,7 @@ def isolated_labels_asw(
         embed=embed,
         cluster=False,
         iso_threshold=iso_threshold,
+        scale=scale,
         verbose=verbose,
     )
 
@@ -124,6 +126,7 @@ def isolated_labels(
     embed,
     cluster=True,
     iso_threshold=None,
+    scale=True,
     return_all=False,
     verbose=True,
 ):
@@ -143,6 +146,7 @@ def isolated_labels(
     :param iso_threshold: max number of batches per label for label to be considered as
         isolated, if iso_threshold is integer.
         If iso_threshold=None, consider minimum number of batches that labels are present in
+    :param scale: Whether to scale the score between 0 and 1. Only relevant for ASW scores.
     :param return_all: return scores for all isolated labels instead of aggregated mean
     :param verbose:
     :return:
@@ -168,6 +172,7 @@ def isolated_labels(
             label,
             embed,
             cluster,
+            scale=scale,
             verbose=verbose,
         )
         scores[label] = score
@@ -186,6 +191,7 @@ def score_isolated_label(
     embed,
     cluster=True,
     iso_label_key="iso_label",
+    scale=True,
     verbose=False,
 ):
     """
@@ -199,6 +205,7 @@ def score_isolated_label(
         silhouette score on grouping of isolated label vs all other remaining labels
     :param iso_label_key: name of key to use for cluster assignment for F1 score or
         isolated-vs-rest assignment for silhouette score
+    :param scale: Whether to scale the score between 0 and 1. Only relevant for ASW scores.
     :param verbose:
     :return:
         Isolated label score
@@ -235,13 +242,14 @@ def score_isolated_label(
         score = max_f1(adata, label_key, iso_label_key, isolated_label, argmax=False)
     else:
         # AWS score between isolated label vs rest
-
         if "silhouette_temp" not in adata.obs:
             adata.obs["silhouette_temp"] = silhouette_samples(
                 adata.obsm[embed], adata.obs[label_key]
             )
         # aggregate silhouette scores for isolated label only
         score = adata.obs[adata.obs[label_key] == isolated_label].silhouette_temp.mean()
+        if scale:
+            score = (score + 1) / 2
 
     if verbose:
         print(f"{isolated_label}: {score}")

--- a/tests/metrics/test_isolated_label.py
+++ b/tests/metrics/test_isolated_label.py
@@ -43,7 +43,7 @@ def test_isolated_labels_ASW(adata_pca):
         verbose=True,
     )
     LOGGER.info(f"score: {score}")
-    assert_near_exact(score, 0.14066337049007416, diff=1e-3)
+    assert_near_exact(score, 0.5703811198472977, diff=1e-3)
 
 
 def test_isolated_labels_f1_perfect(adata_pca):

--- a/tests/metrics/test_silhouette_metrics.py
+++ b/tests/metrics/test_silhouette_metrics.py
@@ -41,16 +41,3 @@ def test_silhouette_batch_empty(adata_pca):
     assert np.isnan(sil_means)
     assert sil_df.shape[0] == 0
     LOGGER.info(sil_df)
-
-
-def test_isolated_labels_silhouette(adata_pca):
-    score = scib.me.isolated_labels(
-        adata_pca,
-        label_key="celltype",
-        batch_key="batch",
-        embed="X_pca",
-        cluster=False,
-        verbose=True,
-    )
-    LOGGER.info(f"score: {score}")
-    assert_near_exact(score, 0.14066337049007416, diff=1e-3)


### PR DESCRIPTION
Isolated label ASW is not scaled, so that the expected output range would be between -1 and +1

https://github.com/theislab/scib/blob/98ee9a20260993ca5df960054dcc82ff8fd75b20/scib/metrics/isolated_labels.py#L237-L249

**Solution:** Add scaling option to metric