### PR TITLE
provide number of columns to `pd.read_table`

### DIFF
--- a/scib/metrics/lisi.py
+++ b/scib/metrics/lisi.py
@@ -447,11 +447,12 @@ def compute_simpson_index_graph(
         lists = np.zeros(0)
         return lists
 
+    names = ['index'] + [f'n_{i}' for i in range(n_neighbors)]
     # read distances and indices with nan value handling
-    indices = pd.read_table(index_file, index_col=0, header=None, sep=",")
+    indices = pd.read_table(index_file, index_col=0, header=None, sep=",", names=names)
     indices = indices.T
 
-    distances = pd.read_table(distance_file, index_col=0, header=None, sep=",")
+    distances = pd.read_table(distance_file, index_col=0, header=None, sep=",", names=names)
     distances = distances.T
 
     # get cell ids


### PR DESCRIPTION
It may be the case that the first row of any of the `graph_lisi*txt` files does not contain values for all of the `n_neighbors` (e.g. files attached), thus the line

https://github.com/theislab/scib/blob/cce7aaa65ccc18649e141e30464361d1fc67ea77/scib/metrics/lisi.py#L451

 raises an exception: `ParserError: Error tokenizing data. C error: Expected 21 fields in line 2, saw 91`. ([more info](https://stackoverflow.com/questions/15242746/handling-variable-number-of-columns-with-pandas-python)).

This PR explictly provides column names to make sure it allocates the total number of columns.

[graph_lisi_indices_0.txt](https://github.com/theislab/scib/files/11142360/graph_lisi_indices_0.txt)
[graph_lisi_distances_0.txt](https://github.com/theislab/scib/files/11142361/graph_lisi_distances_0.txt)
