### PR TITLE
support scanpy 1.10

### DIFF
--- a/scib/metrics/ari.py
+++ b/scib/metrics/ari.py
@@ -1,13 +1,11 @@
 import numpy as np
 import pandas as pd
 import scipy.special
-from scanpy._utils import deprecated_arg_names
 from sklearn.metrics.cluster import adjusted_rand_score
 
 from ..utils import check_adata, check_batch
 
 
-@deprecated_arg_names({"group1": "cluster_key", "group2": "label_key"})
 def ari(adata, cluster_key, label_key, implementation=None):
     """Adjusted Rand Index
 

--- a/scib/metrics/highly_variable_genes.py
+++ b/scib/metrics/highly_variable_genes.py
@@ -1,6 +1,5 @@
 import numpy as np
 import scanpy as sc
-from scanpy._utils import deprecated_arg_names
 
 from ..utils import split_batches
 
@@ -36,7 +35,6 @@ def precompute_hvg_batch(adata, batch, features, n_hvg=500, save_hvg=False):
         return hvg_dir
 
 
-@deprecated_arg_names({"batch": "batch_key"})
 def hvg_overlap(adata_pre, adata_post, batch_key, n_hvg=500, verbose=False):
     """Highly variable gene overlap
 

--- a/scib/metrics/nmi.py
+++ b/scib/metrics/nmi.py
@@ -1,15 +1,11 @@
 import os
 import subprocess
 
-from scanpy._utils import deprecated_arg_names
 from sklearn.metrics.cluster import normalized_mutual_info_score
 
 from ..utils import check_adata, check_batch
 
 
-@deprecated_arg_names(
-    {"group1": "cluster_key", "group2": "label_key", "method": "implementation"}
-)
 def nmi(adata, cluster_key, label_key, implementation="arithmetic", nmi_dir=None):
     """Normalized mutual information
 

--- a/scib/metrics/silhouette.py
+++ b/scib/metrics/silhouette.py
@@ -1,10 +1,8 @@
 import numpy as np
 import pandas as pd
-from scanpy._utils import deprecated_arg_names
 from sklearn.metrics.cluster import silhouette_samples, silhouette_score
 
 
-@deprecated_arg_names({"group_key": "label_key"})
 def silhouette(adata, label_key, embed, metric="euclidean", scale=True):
     """Average silhouette width (ASW)
 
@@ -50,7 +48,6 @@ def silhouette(adata, label_key, embed, metric="euclidean", scale=True):
     return asw
 
 
-@deprecated_arg_names({"group_key": "label_key"})
 def silhouette_batch(
     adata,
     batch_key,


### PR DESCRIPTION
closes #401 

- removes instances of `scanpy._utils.deprecated_arg_names`, which has been removed as of scanpy 1.10