### PR TITLE
Update python-igraph dependency to igraph

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ rpy2 = rpy2>=3; anndata2ri
 test = pytest; pytest-icdiff; pytest-cov; codecov
 dev = build; twine; isort; bump2version; pre-commit
 docs = sphinx; sphinx_rtd_theme; myst_parser; sphinx-automodapi
-louvain = python-igraph; louvain>=0.8
+louvain = igraph; louvain>=0.8
 bbknn = bbknn ==1.3.9
 scanorama = scanorama >=1.7.4
 mnn = mnnpy ==0.1.9.5


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for an explanation. This is one of the most popular packages on PyPI that still depends on the deprecated `python-igraph` package name.