### PR TITLE
M.A might not be available, you should use M.toarray()

### DIFF
--- a/scib/metrics/utils.py
+++ b/scib/metrics/utils.py
@@ -138,7 +138,7 @@ def diffusion_nn(adata, k, max_iterations=26):
         )
 
     M.setdiag(0)
-    k_indices = np.argpartition(M.A, -k, axis=1)[:, -k:]
+    k_indices = np.argpartition(M.toarray(), -k, axis=1)[:, -k:]
 
     return k_indices
 


### PR DESCRIPTION
In some versions of scipy(e.g. 1.14), M.A might not be available. In such cases, you should use M.toarray() to convert the sparse matrix to a dense one.